### PR TITLE
A few cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,5 @@ __pycache__/*
 *.swp
 *.egg-info
 _data/*
-site/_build/*
-site/_generated/*
-site/content/_generated/*
-# Ignore text version of issues table
-top_issues_table.md
+_build/*
+_generated/*

--- a/analysis_template.md
+++ b/analysis_template.md
@@ -345,7 +345,12 @@ axes[0].set_xlabel('Time')
 axes[0].set_ylabel(f'# Merged PRs / {binsize} interval')
 axes[1].set_ylim(axes[0].get_ylim())
 fig.autofmt_xdate()
-plt.show()
+
+# TODO: Replace this with `glue` once the glue:figure directive supports
+# alt-text
+import os
+os.makedirs("thumbs", exist_ok=True)
+plt.savefig("thumbs/{{ project }}.png", bbox_inches="tight")
 ```
 
 ### Mergeability of Open PRs

--- a/conf.py
+++ b/conf.py
@@ -38,7 +38,14 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', "analysis_template.md"]
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    "analysis_template.md",
+    "README.rst",
+    "devstats-data/*"
+]
 execution_excludepatterns = ["analysis_template.md"]
 
 

--- a/index.md
+++ b/index.md
@@ -3,12 +3,15 @@
 This website tracks the recent development history of the Scientific Python
 ecosystem.
 
+% TODO: Replace markdown image links with `glue:figure` once it starts
+% supporting alt text
+
 ````{panels}
 :container: +full-width text-center
 :column: col-lg-4 px-2 py-2
 :card:
 
-![Merged NumPy PRs over time](_images/numpy_19_0.png)
+![Merged NumPy PRs over time](_generated/thumbs/numpy.png)
 
 ```{link-button} _generated/numpy
 :text: NumPy stats
@@ -18,7 +21,7 @@ ecosystem.
 
 ---
 
-![Merged SciPy PRs over time](_images/scipy_19_0.png)
+![Merged SciPy PRs over time](_generated/thumbs/scipy.png)
 
 ```{link-button} _generated/scipy
 :text: SciPy stats
@@ -28,7 +31,7 @@ ecosystem.
 
 ---
 
-![Merged Matplotlib PRs over time](_images/matplotlib_19_0.png)
+![Merged Matplotlib PRs over time](_generated/thumbs/matplotlib.png)
 
 ```{link-button} _generated/matplotlib
 :text: Matplotlib stats
@@ -37,7 +40,7 @@ ecosystem.
 ```
 ---
 
-![Merged Pandas PRs over time](_images/pandas_19_0.png)
+![Merged Pandas PRs over time](_generated/thumbs/pandas.png)
 
 ```{link-button} _generated/pandas
 :text: Pandas stats
@@ -47,7 +50,7 @@ ecosystem.
 
 ---
 
-![Merged scikit-learn PRs over time](_images/scikit-learn_19_0.png)
+![Merged scikit-learn PRs over time](_generated/thumbs/scikit-learn.png)
 
 ```{link-button} _generated/scikit-learn
 :text: scikit-learn stats
@@ -57,7 +60,7 @@ ecosystem.
 
 ---
 
-![Merged scikit-image PRs over time](_images/scikit-image_19_0.png)
+![Merged scikit-image PRs over time](_generated/thumbs/scikit-image.png)
 
 ```{link-button} _generated/scikit-image
 :text: scikit-image stats
@@ -67,7 +70,7 @@ ecosystem.
 
 ---
 
-![Merged NetworkX PRs over time](_images/networkx_19_0.png)
+![Merged NetworkX PRs over time](_generated/thumbs/networkx.png)
 
 ```{link-button} _generated/networkx
 :text: NetworkX stats


### PR DESCRIPTION
A few cleanups after moving the site to the top level of the repo in #19.

Fixes up the `.gitignore` and `conf.py` to reflect the current repo structure.

I've also redone how the thumbnail images are linked in the front page. The current approach gives sphinx warnings about unreadable images (even though it works fine). I'd like to get rid of the sphinx warnings so that we can add CI to check that the notebooks run error-free, which requires elevating sphinx warnings to errors. I've simply added a few lines that saves figures as separate thumbnails which can then be linked to. This is slightly annoying becuase technically then we are generating and saving the same images twice in the build process, but this should have minimal impact on the execution time (and 0 impact on the site/repo size, since these images are generated during the build). The ideal solution would be to use `glue:figure`, but this doesn't support alt-text yet. The current approach is intended to be a temporary solution that checks all the boxes (no sphinx warnings, supports alt text, generated images).