### PR TITLE
Fix off by 1 error in Pony factor calculation and logarithmic plotting

### DIFF
--- a/analysis_template.md
+++ b/analysis_template.md
@@ -576,7 +576,11 @@ pony_factor = np.searchsorted(
 ) + 1
 
 fig, ax = plt.subplots()
-ax.plot(np.cumsum(num_merged_prs_per_author), ".")
+ax.plot(
+    np.arange(len(num_merged_prs_per_author)) + 1,
+    np.cumsum(num_merged_prs_per_author),
+    "."
+)
 ax.set_title(f"How the pony factor is calculated")
 ax.set_xlabel("# unique contributors")
 ax.set_xscale("log")

--- a/analysis_template.md
+++ b/analysis_template.md
@@ -573,7 +573,7 @@ num_merged_prs = num_merged_prs_per_author.sum()
 pf_thresh = 0.5
 pony_factor = np.searchsorted(
     np.cumsum(num_merged_prs_per_author), num_merged_prs * pf_thresh
-)
+) + 1
 
 fig, ax = plt.subplots()
 ax.plot(np.cumsum(num_merged_prs_per_author), ".")


### PR DESCRIPTION
Closes #36.

- Fix off by 1 error in Pony factor calculation. `numpy.searchsorted` determines an index N for where the threshold should
be inserted. So we need to add 1 to this index as the Pony factor constitutes the majority > 50% of all PRs.
- Ensure that contributor with most PRs is displayed. `ax.plot(np.cumsum(num_merged_prs_per_author), ".")` creates an automatic index starting with 0. However, because the x axis uses the log scale, the first value at 0 is never shown! To fix this we pass in our own index starting with 1.

cc @rossbar 