### PR TITLE
Refactor Makefile to work with templated devstats tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/*
 _data/*
 _build/*
 _generated/*
+_template/*

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 
 PROJECTS = numpy scipy matplotlib pandas scikit-learn scikit-image networkx astropy sunpy
 ISSUE_DATA = $(patsubst %, devstats-data/%_issues.json, $(PROJECTS))
-PR_DATA = $(patsubst %, devstats-data/%_PRs.json, $(PROJECTS))
+PR_DATA = $(patsubst %, devstats-data/%_prs.json, $(PROJECTS))
 REPORTS = $(patsubst %, _generated/%/index.md, $(PROJECTS))
 
 $(REPORTS) : $(ISSUE_DATA) $(PR_DATA)
@@ -22,7 +22,7 @@ $(REPORTS) : $(ISSUE_DATA) $(PR_DATA)
 devstats-data/%_issues.json :
 	devstats query -o devstats-data $* $*
 
-devstats-data/%_PRs.json : devstats-data/%_issues.json
+devstats-data/%_prs.json : devstats-data/%_issues.json
 
 _generated/%/index.md:
 	devstats template -o _template $*

--- a/Makefile
+++ b/Makefile
@@ -12,38 +12,28 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-_generated/numpy.md:
-	devstats publish numpy
+PROJECTS = numpy scipy matplotlib pandas scikit-learn scikit-image networkx astropy sunpy
+ISSUE_DATA = $(patsubst %, devstats-data/%_issues.json, $(PROJECTS))
+PR_DATA = $(patsubst %, devstats-data/%_PRs.json, $(PROJECTS))
+REPORTS = $(patsubst %, _generated/%/index.md, $(PROJECTS))
 
-_generated/scipy.md:
-	devstats publish scipy
+$(REPORTS) : $(ISSUE_DATA) $(PR_DATA)
 
-_generated/matplotlib.md:
-	devstats publish matplotlib
+devstats-data/%_issues.json :
+	devstats query -o devstats-data $* $*
 
-_generated/pandas.md:
-	devstats publish pandas
+devstats-data/%_PRs.json : devstats-data/%_issues.json
 
-_generated/scikit-learn.md:
-	devstats publish scikit-learn
+_generated/%/index.md:
+	devstats template -o _template $*
+	devstats publish -t _template -o _generated $*
+	ln -s $(PWD)/devstats-data _generated/$*
 
-_generated/scikit-image.md:
-	devstats publish scikit-image
-
-_generated/networkx.md:
-	devstats publish networkx
-
-_generated/astropy.md:
-	devstats publish astropy
-
-_generated/sunpy.md:
-	devstats publish sunpy
-
-html : _generated/numpy.md _generated/scipy.md _generated/matplotlib.md _generated/pandas.md _generated/scikit-learn.md _generated/scikit-image.md _generated/networkx.md _generated/astropy.md _generated/sunpy.md
+html : $(REPORTS)
 	$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 
-clean: 
-	rm -rf _build _generated
+clean:
+	rm -rf _build _template _generated
 
 .PHONY: help clean
 

--- a/conf.py
+++ b/conf.py
@@ -44,7 +44,8 @@ exclude_patterns = [
     '.DS_Store',
     "analysis_template.md",
     "README.md",
-    "devstats-data/*"
+    "devstats-data/*",
+    "_template"
 ]
 nb_execution_excludepatterns = ["analysis_template.md"]
 

--- a/index.md
+++ b/index.md
@@ -11,9 +11,9 @@ ecosystem.
 :gutter: 2
 
 ````{grid-item-card}
-![Merged NumPy PRs over time](_generated/thumbs/numpy.png)
+![Merged NumPy PRs over time](_generated/numpy/thumbs/numpy.png)
 
-```{button-ref} _generated/numpy
+```{button-ref} _generated/numpy/index
 :color: primary
 :expand:
 NumPy
@@ -21,9 +21,9 @@ NumPy
 ````
 
 ````{grid-item-card}
-![Merged SciPy PRs over time](_generated/thumbs/scipy.png)
+![Merged SciPy PRs over time](_generated/scipy/thumbs/scipy.png)
 
-```{button-ref} _generated/scipy
+```{button-ref} _generated/scipy/index
 :color: primary
 :expand:
 SciPy
@@ -31,9 +31,9 @@ SciPy
 ````
 
 ````{grid-item-card}
-![Merged Matplotlib PRs over time](_generated/thumbs/matplotlib.png)
+![Merged Matplotlib PRs over time](_generated/matplotlib/thumbs/matplotlib.png)
 
-```{button-ref} _generated/matplotlib
+```{button-ref} _generated/matplotlib/index
 :color: primary
 :expand:
 Matplotlib
@@ -41,9 +41,9 @@ Matplotlib
 ````
 
 ````{grid-item-card}
-![Merged Pandas PRs over time](_generated/thumbs/pandas.png)
+![Merged Pandas PRs over time](_generated/pandas/thumbs/pandas.png)
 
-```{button-ref} _generated/pandas
+```{button-ref} _generated/pandas/index
 :color: primary
 :expand:
 Pandas
@@ -51,9 +51,9 @@ Pandas
 ````
 
 ````{grid-item-card}
-![Merged scikit-learn PRs over time](_generated/thumbs/scikit-learn.png)
+![Merged scikit-learn PRs over time](_generated/scikit-learn/thumbs/scikit-learn.png)
 
-```{button-ref} _generated/scikit-learn
+```{button-ref} _generated/scikit-learn/index
 :color: primary
 :expand:
 scikit-learn
@@ -61,9 +61,9 @@ scikit-learn
 ````
 
 ````{grid-item-card}
-![Merged scikit-image PRs over time](_generated/thumbs/scikit-image.png)
+![Merged scikit-image PRs over time](_generated/scikit-image/thumbs/scikit-image.png)
 
-```{button-ref} _generated/scikit-image
+```{button-ref} _generated/scikit-image/index
 :color: primary
 :expand:
 scikit-image
@@ -71,9 +71,9 @@ scikit-image
 ````
 
 ````{grid-item-card}
-![Merged NetworkX PRs over time](_generated/thumbs/networkx.png)
+![Merged NetworkX PRs over time](_generated/networkx/thumbs/networkx.png)
 
-```{button-ref} _generated/networkx
+```{button-ref} _generated/networkx/index
 :color: primary
 :expand:
 NetworkX
@@ -81,9 +81,9 @@ NetworkX
 ````
 
 ````{grid-item-card}
-![Merged astropy PRs over time](_generated/thumbs/astropy.png)
+![Merged astropy PRs over time](_generated/astropy/thumbs/astropy.png)
 
-```{button-ref} _generated/astropy
+```{button-ref} _generated/astropy/index
 :color: primary
 :expand:
 Astropy
@@ -91,9 +91,9 @@ Astropy
 ````
 
 ````{grid-item-card}
-![Merged sunpy PRs over time](_generated/thumbs/sunpy.png)
+![Merged sunpy PRs over time](_generated/sunpy/thumbs/sunpy.png)
 
-```{button-ref} _generated/sunpy
+```{button-ref} _generated/sunpy/index
 :color: primary
 :expand:
 sunpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 pandas
 bokeh
 # For the site
-devstats==0.1rc2 
+devstats==0.1rc3
 sphinx
 sphinx_design
 myst-nb


### PR DESCRIPTION
**This is not a priority for 5/26, and can be reviewed after the summit.**

This PR works with my [template-publish](https://github.com/stefanv/devstats/tree/template-publish) branch.

It refactors the Makefile and updates Python paths accordingly.

Even if this PR is not merged, the Makefile refactoring should be useful (after being slightly adapted) for the existing main branch.
